### PR TITLE
new internal representation

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,104 @@
+package compat
+
+import (
+	"go/types"
+)
+
+// API
+type API struct {
+	// Packages included directly in the API.
+	Packages []*Package
+	// Reachable is the set of all objects that are reachable from the API.
+	Reachable []*Object
+}
+
+// NewAPI creates an empty API.
+func NewAPI() *API {
+	return &API{}
+}
+
+func (a *API) LookupSymbol(sym *Symbol) *Object {
+	for _, obj := range a.Reachable {
+		if &obj.Symbol == sym {
+			return obj
+		}
+	}
+
+	return nil
+}
+
+type Package struct {
+	Path    string             `json:"path"`
+	Objects map[string]*Object `json:"objects,omitempty"`
+}
+
+func NewPackage(path string) *Package {
+	return &Package{
+		Path:    path,
+		Objects: make(map[string]*Object),
+	}
+}
+
+type DeclarationType string
+
+const (
+	TypeDeclaration  DeclarationType = "type"
+	AliasDeclaration                 = "alias"
+	VarDeclaration                   = "var"
+	ConstDeclaration                 = "const"
+	FuncDeclaration                  = "func"
+)
+
+type Type string
+
+const (
+	StructType    Type = "struct"
+	BasicType          = "basic"
+	SliceType          = "slice"
+	ArrayType          = "array"
+	FuncType           = "func"
+	ChanType           = "chan"
+	MapType            = "map"
+	PointerType        = "pointer"
+	InterfaceType      = "interface"
+)
+
+type Symbol struct {
+	Package string `json:"package"`
+	Name    string `json:"name"`
+}
+
+type Object struct {
+	Symbol     Symbol          `json:"symbol"`
+	Type       DeclarationType `json:"type"`
+	Definition *Definition     `json:"definition,omitempty"`
+	Methods    []*Func         `json:"methods,omitempty"`
+}
+
+type Definition struct {
+	Type      Type          `json:"type"`
+	Symbol    *Symbol       `json:"symbol,omitempty"`
+	Elem      *Definition   `json:"elem,omitempty"`
+	Key       *Definition   `json:"key,omitempty"`
+	Len       int64         `json:"len,omitempty"`
+	ChanDir   types.ChanDir `json:"chandir,omitempty"`
+	Fields    []*Field      `json:"fields,omitempty"`
+	Functions []*Func       `json:"functions,omitempty"`
+	Signature *Signature    `json:"signature,omitempty"`
+}
+
+type Field struct {
+	Name string
+	Type *Definition
+}
+
+type Func struct {
+	Signature
+	Name string
+}
+
+type Signature struct {
+	Params   []*Definition
+	Results  []*Definition
+	Variadic bool
+}

--- a/cmd/gocompat/reach.go
+++ b/cmd/gocompat/reach.go
@@ -26,8 +26,8 @@ func (c reachCommand) Execute(args []string) error {
 	}
 
 	var reachedString []string
-	for r := range api.Reachable {
-		str := fmt.Sprintf("\"%s\".%s", r.Pkg().Path(), r.Name())
+	for _, obj := range api.Reachable {
+		str := fmt.Sprintf("\"%s\".%s", obj.Symbol.Package, obj.Symbol.Name)
 		reachedString = append(reachedString, str)
 	}
 

--- a/compare_test.go
+++ b/compare_test.go
@@ -230,37 +230,13 @@ func TestCompareObjects(t *testing.T) {
 			require := require.New(t)
 			a, ok := FixtureObjects[fixture.A]
 			require.True(ok)
+			aobj := ConvertObject(a)
 			b, ok := FixtureObjects[fixture.B]
 			require.True(ok)
-			actual := CompareObjects(a, b)
+			bobj := ConvertObject(b)
+			bobj.Symbol = aobj.Symbol
+			actual := CompareObjects(aobj, bobj)
 			require.Equal(fixture.Expected, actual)
-		})
-	}
-}
-
-type FixtureBasicTypeObjects struct {
-	Name   string
-	Result string
-}
-
-var FixturesBasicTypeObjects = []FixtureBasicTypeObjects{{
-	Name:   "StructA1",
-	Result: "type github.com/smola/gocompat.StructA1 struct",
-}, {
-	Name:   "Named1",
-	Result: "type github.com/smola/gocompat.Named1 int",
-}, {
-	Name:   "Named3",
-	Result: "type github.com/smola/gocompat.Named3 struct",
-}}
-
-func TestBasicTypeObjects(t *testing.T) {
-	for _, f := range FixturesBasicTypeObjects {
-		t.Run(f.Name, func(t *testing.T) {
-			require := require.New(t)
-			obj, ok := FixtureObjects[f.Name]
-			require.True(ok)
-			require.Equal(f.Result, basicType(obj))
 		})
 	}
 }

--- a/convert.go
+++ b/convert.go
@@ -1,0 +1,199 @@
+package compat
+
+import (
+	"go/types"
+)
+
+func ConvertObject(obj types.Object) *Object {
+	res := &Object{
+		Symbol: Symbol{
+			Package: obj.Pkg().Path(),
+			Name:    obj.Name(),
+		},
+	}
+
+	switch obj := obj.(type) {
+	case *types.TypeName:
+		res.Type = TypeDeclaration
+		if obj.IsAlias() {
+			res.Type = AliasDeclaration
+		}
+	case *types.Func:
+		res.Type = FuncDeclaration
+	case *types.Var:
+		res.Type = VarDeclaration
+	case *types.Const:
+		res.Type = ConstDeclaration
+	}
+
+	if res.Type == AliasDeclaration {
+		res.Definition = typeToShallowDefinition(obj.Type())
+		return res
+	}
+
+	if _, ok := obj.Type().Underlying().(*types.Basic); ok {
+		res.Definition = typeToShallowDefinition(obj.Type())
+	} else {
+		res.Definition = typeToDefinition(obj.Type())
+	}
+
+	switch typ := obj.Type().(type) {
+	case *types.Named:
+		res.Methods = methoderToFuncs(true, typ)
+	}
+
+	return res
+}
+
+func typeToShallowDefinition(typ types.Type) *Definition {
+	switch typ := typ.(type) {
+	case *types.Basic:
+		return &Definition{
+			Type:   BasicType,
+			Symbol: &Symbol{Name: typ.Name()},
+		}
+	case *types.Named:
+		tn := typ.Obj()
+		var pkg string
+		if tn.Pkg() != nil {
+			pkg = tn.Pkg().Path()
+		}
+		return &Definition{
+			Symbol: &Symbol{Package: pkg, Name: tn.Name()},
+		}
+	}
+
+	return typeToDefinition(typ)
+}
+
+func typeToDefinition(typ types.Type) *Definition {
+	underlying := typ.Underlying()
+	switch underlying := underlying.(type) {
+	case *types.Struct:
+		return structToDefinition(underlying)
+	case *types.Signature:
+		return signatureToDefinition(underlying)
+	case *types.Slice:
+		return sliceToDefinition(underlying)
+	case *types.Array:
+		return arrayToDefinition(underlying)
+	case *types.Chan:
+		return chanToDefinition(underlying)
+	case *types.Map:
+		return mapToDefinition(underlying)
+	case *types.Pointer:
+		return pointerToDefinition(underlying)
+	case *types.Interface:
+		return interfaceToDefinition(underlying)
+	}
+	panic("unhandled type")
+}
+
+func methoderToFuncs(exportedOnly bool, typ methoder) []*Func {
+	var funcs []*Func
+	for i := 0; i < typ.NumMethods(); i++ {
+		method := typ.Method(i)
+		if exportedOnly && !method.Exported() {
+			continue
+		}
+		funcs = append(funcs, &Func{
+			Name:      method.Name(),
+			Signature: signatureToSignature(method.Type().(*types.Signature)),
+		})
+	}
+	return funcs
+}
+
+func structToDefinition(typ *types.Struct) *Definition {
+	def := &Definition{
+		Type: StructType,
+	}
+
+	for i := 0; i < typ.NumFields(); i++ {
+		field := typ.Field(i)
+		if !field.Exported() {
+			continue
+		}
+		def.Fields = append(def.Fields, varToField(field))
+	}
+
+	return def
+}
+
+func signatureToDefinition(typ *types.Signature) *Definition {
+	sig := signatureToSignature(typ)
+	return &Definition{
+		Type:      FuncType,
+		Signature: &sig,
+	}
+}
+
+func signatureToSignature(typ *types.Signature) Signature {
+	return Signature{
+		Params:   tupleToSymbols(typ.Params()),
+		Results:  tupleToSymbols(typ.Results()),
+		Variadic: typ.Variadic(),
+	}
+}
+
+func sliceToDefinition(typ *types.Slice) *Definition {
+	return &Definition{
+		Type: SliceType,
+		Elem: typeToShallowDefinition(typ.Elem()),
+	}
+}
+
+func arrayToDefinition(typ *types.Array) *Definition {
+	return &Definition{
+		Type: ArrayType,
+		Len:  typ.Len(),
+		Elem: typeToShallowDefinition(typ.Elem()),
+	}
+}
+
+func chanToDefinition(typ *types.Chan) *Definition {
+	return &Definition{
+		Type:    ChanType,
+		ChanDir: typ.Dir(),
+		Elem:    typeToShallowDefinition(typ.Elem()),
+	}
+}
+
+func mapToDefinition(typ *types.Map) *Definition {
+	return &Definition{
+		Type: MapType,
+		Key:  typeToShallowDefinition(typ.Key()),
+		Elem: typeToShallowDefinition(typ.Elem()),
+	}
+}
+
+func pointerToDefinition(typ *types.Pointer) *Definition {
+	return &Definition{
+		Type: PointerType,
+		Elem: typeToShallowDefinition(typ.Elem()),
+	}
+}
+
+func interfaceToDefinition(typ *types.Interface) *Definition {
+	return &Definition{
+		Type:      InterfaceType,
+		Functions: methoderToFuncs(false, typ),
+	}
+}
+
+func tupleToSymbols(tup *types.Tuple) []*Definition {
+	var res []*Definition
+	for i := 0; i < tup.Len(); i++ {
+		field := tup.At(i)
+		res = append(res, typeToShallowDefinition(field.Type()))
+	}
+
+	return res
+}
+
+func varToField(obj *types.Var) *Field {
+	return &Field{
+		Name: obj.Name(),
+		Type: typeToShallowDefinition(obj.Type()),
+	}
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,213 @@
+package compat
+
+import (
+	"fmt"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const thisPkg = "github.com/smola/gocompat"
+
+type ConvertObjectFixture struct {
+	Name     string
+	Input    string
+	Expected *Object
+}
+
+var ConvertObjectFixtures = []ConvertObjectFixture{{
+	Name:  "empty struct",
+	Input: "StructA1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "StructA1"},
+		Type:   TypeDeclaration,
+		Definition: &Definition{
+			Type: StructType,
+		},
+	}}, {
+	Name:  "struct with fields",
+	Input: "StructA4",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "StructA4"},
+		Type:   TypeDeclaration,
+		Definition: &Definition{
+			Type: StructType,
+			Fields: []*Field{{
+				Name: "Field1",
+				Type: &Definition{
+					Type:   BasicType,
+					Symbol: &Symbol{Name: "string"},
+				}}, {
+				Name: "Field2",
+				Type: &Definition{
+					Type:   BasicType,
+					Symbol: &Symbol{Name: "int"},
+				}},
+			}}}}, {
+	Name:  "type alias with basic type",
+	Input: "TypeAlias1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "TypeAlias1"},
+		Type:   AliasDeclaration,
+		Definition: &Definition{
+			Type:   BasicType,
+			Symbol: &Symbol{Name: "int"},
+		},
+	}}, {
+	Name:  "type alias with struct",
+	Input: "TypeAlias3",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "TypeAlias3"},
+		Type:   AliasDeclaration,
+		Definition: &Definition{
+			Symbol: &Symbol{Package: thisPkg, Name: "StructA3"},
+		},
+	}}, {
+	Name:  "func",
+	Input: "Func5",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Func5"},
+		Type:   FuncDeclaration,
+		Definition: &Definition{
+			Type: FuncType,
+			Signature: &Signature{
+				Params: []*Definition{
+					{Type: BasicType, Symbol: &Symbol{Name: "string"}},
+					{Type: BasicType, Symbol: &Symbol{Name: "int"}},
+				},
+				Results: []*Definition{
+					{Type: BasicType, Symbol: &Symbol{Name: "string"}},
+				},
+			},
+		},
+	}}, {
+	Name:  "func variadic",
+	Input: "Func8",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Func8"},
+		Type:   FuncDeclaration,
+		Definition: &Definition{
+			Type: FuncType,
+			Signature: &Signature{
+				Params: []*Definition{{
+					Type: SliceType,
+					Elem: &Definition{
+						Type:   BasicType,
+						Symbol: &Symbol{Name: "string"}},
+				}},
+				Variadic: true,
+			},
+		},
+	}}, {
+	Name:  "struct with method",
+	Input: "StructB1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "StructB1"},
+		Type:   TypeDeclaration,
+		Definition: &Definition{
+			Type: StructType,
+		},
+		Methods: []*Func{
+			{Name: "Func1", Signature: Signature{}},
+		},
+	}}, {
+	Name:  "array of ints",
+	Input: "Array1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Array1"},
+		Type:   VarDeclaration,
+		Definition: &Definition{
+			Type: ArrayType,
+			Len:  20,
+			Elem: &Definition{
+				Type:   BasicType,
+				Symbol: &Symbol{Name: "int"},
+			},
+		},
+	}}, {
+	Name:  "read chan",
+	Input: "ChanRead1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "ChanRead1"},
+		Type:   VarDeclaration,
+		Definition: &Definition{
+			Type:    ChanType,
+			ChanDir: types.RecvOnly,
+			Elem: &Definition{
+				Type:   BasicType,
+				Symbol: &Symbol{Name: "int"},
+			},
+		},
+	}}, {
+	Name:  "map",
+	Input: "Map1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Map1"},
+		Type:   VarDeclaration,
+		Definition: &Definition{
+			Type: MapType,
+			Key: &Definition{
+				Type:   BasicType,
+				Symbol: &Symbol{Name: "int"},
+			},
+			Elem: &Definition{
+				Type:   BasicType,
+				Symbol: &Symbol{Name: "string"},
+			},
+		},
+	}}, {
+	Name:  "pointer",
+	Input: "Pointer1",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Pointer1"},
+		Type:   VarDeclaration,
+		Definition: &Definition{
+			Type: PointerType,
+			Elem: &Definition{
+				Type:   BasicType,
+				Symbol: &Symbol{Name: "int"},
+			},
+		},
+	}}, {
+	Name:  "interface",
+	Input: "Interface3",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Interface3"},
+		Type:   TypeDeclaration,
+		Definition: &Definition{
+			Type: InterfaceType,
+			Functions: []*Func{
+				{Name: "F", Signature: Signature{
+					Params: []*Definition{
+						{Type: BasicType, Symbol: &Symbol{Name: "string"}},
+					},
+				}},
+			},
+		},
+	}}, {
+	Name:  "interface with private method",
+	Input: "Interface4",
+	Expected: &Object{
+		Symbol: Symbol{Package: thisPkg, Name: "Interface4"},
+		Type:   TypeDeclaration,
+		Definition: &Definition{
+			Type: InterfaceType,
+			Functions: []*Func{
+				{Name: "f"},
+			},
+		},
+	}}}
+
+func TestConvertObjects(t *testing.T) {
+	for _, fixture := range ConvertObjectFixtures {
+		name := fmt.Sprintf("%s_%s", fixture.Name, fixture.Input)
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			a, ok := FixtureObjects[fixture.Input]
+			require.True(ok)
+			actual := ConvertObject(a)
+			require.Equal(fixture.Expected, actual)
+		})
+	}
+}

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -7,17 +7,20 @@ import (
 )
 
 func init() {
-	api, err := reachableFromPackages(true, "file=fixtures_test.go")
+	conf := &packages.Config{
+		Mode:  packages.LoadTypes,
+		Tests: true,
+	}
+
+	loadedPackages, err := packages.Load(conf, "file=fixtures_test.go")
 	if err != nil {
 		panic(err)
 	}
 
-	if len(api.Reachable) == 0 {
-		panic("no objects parsed")
-	}
-
 	FixtureObjects = make(map[string]types.Object)
-	for obj := range api.Reachable {
+	scope := loadedPackages[0].Types.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
 		FixtureObjects[obj.Name()] = obj
 	}
 }


### PR DESCRIPTION
Use a simpler internal representation for types. This will later enable
serializing them to be able to store and load APIs.
